### PR TITLE
Enable building documentation for all features for docs.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,6 @@ buffering_nocopy_macro = { path = "./nocopy_macro", version = "0.2.0", optional 
 [features]
 copy = []
 nocopy = ["buffering_nocopy_macro"]
+
+[package.metadata.docs.rs]
+all-features = true


### PR DESCRIPTION
The documentation rendered by [docs.rs](https://docs.rs) is lacking everything this crate has to offer (as seen here: https://docs.rs/buffering/0.4.2/buffering/).

This PR should enable docs.rs to produce documentation for all features. See docs.rs documentation about metadata for custom builds here: https://docs.rs/about